### PR TITLE
SA-3317 Updated nginx configurations to facilitate SSL renewal with no downtime.

### DIFF
--- a/.conf/nginx/alchemy.impact.georgian.io.conf.template
+++ b/.conf/nginx/alchemy.impact.georgian.io.conf.template
@@ -17,7 +17,15 @@ server {
     include             /etc/letsencrypt/options-ssl-nginx.conf;
     ssl_dhparam         /etc/letsencrypt/ssl-dhparams.pem;
 
-    return 301 https://$1.georgian.io$request_uri;
+    location ^~ /.well-known/acme-challenge/ {
+      default_type "text/plain";
+      autoindex off;
+      root /var/www/letsencrypt;
+    }
+
+    location / {
+        return 301 https://$1.georgian.io$request_uri;
+    }
 }
 
 server {


### PR DESCRIPTION
The configuration was missing required parts for renewing the old domain certificates. It worked (and works) fine for the new domain after rebranding.