### PR TITLE
Limit celery autoscale

### DIFF
--- a/docker-compose-staging.yml
+++ b/docker-compose-staging.yml
@@ -67,7 +67,17 @@ services:
     volumes:
       - $GCLOUD_LOCAL_DIR:/root/.config/gcloud
       - $FILESTORE_LOCAL_DIR:/app/__filestore
-    entrypoint: ["celery", "--app=alchemy.ar.ar_celery", "worker", "-Q", "ar_celery", "-c", "2", "--autoscale=100,2", "-l", "info", "--max-tasks-per-child", "1", "-n", "ar_celery"]
+    entrypoint: ["celery"]
+    command: [
+        "--app=alchemy.ar.ar_celery",
+        "worker",
+        "-Q", "ar_celery",
+        "-c", "2",
+        "--autoscale=10,2",
+        "-l", "info",
+        "--max-tasks-per-child", "1",
+        "-n", "ar_celery%I"
+    ]
     depends_on:
       - redis
       - admin_server
@@ -81,7 +91,17 @@ services:
     volumes:
       - $GCLOUD_LOCAL_DIR:/root/.config/gcloud
       - $FILESTORE_LOCAL_DIR:/app/__filestore
-    entrypoint: ["celery", "--app=alchemy.train.train_celery", "worker", "-Q", "train_celery", "-c", "2", "--autoscale=100,2", "-l", "info", "--max-tasks-per-child", "1", "-n", "train_celery"]
+    entrypoint: ["celery"]
+    command: [
+        "--app=alchemy.train.train_celery",
+        "worker",
+        "-Q", "train_celery",
+        "-c", "2",
+        "--autoscale=10,2",
+        "-l", "info",
+        "--max-tasks-per-child", "1",
+        "-n", "train_celery%I"
+    ]
     depends_on:
       - redis
       - admin_server
@@ -95,7 +115,16 @@ services:
     volumes:
       - $GCLOUD_LOCAL_DIR:/root/.config/gcloud
       - $FILESTORE_LOCAL_DIR:/app/__filestore
-    entrypoint: ["celery", "--app=alchemy.train.gcp_celery", "worker", "-Q", "gcp_celery", "-c", "5", "--autoscale=100,2", "-l", "info", "-n", "gcp_celery"]
+    entrypoint: ["celery"]
+    command: [
+        "--app=alchemy.train.gcp_celery",
+        "worker",
+        "-Q", "gcp_celery",
+        "-c", "5",
+        "--autoscale=10,2",
+        "-l", "info",
+        "-n", "gcp_celery%I"
+    ]
     depends_on:
       - redis
       - admin_server

--- a/docker-compose-staging.yml
+++ b/docker-compose-staging.yml
@@ -31,6 +31,7 @@ services:
     ]
     environment:
       - SCRIPT_NAME=/admin
+    restart: on-failure
     depends_on:
       - redis
     logging: *gcp-logger
@@ -54,6 +55,7 @@ services:
         '--flask-port', '5001',
         'annotation_server'
     ]
+    restart: on-failure
     depends_on:
       - redis
       - admin_server
@@ -151,6 +153,7 @@ services:
         source: annotation_static_files
         target: /static_files/annotation_server
         read_only: true
+    restart: on-failure
     depends_on:
       - admin_server
       - annotation_server

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,7 +57,17 @@ services:
     env_file: .env
     image: *img
     volumes: *default-volumes
-    entrypoint: ["celery", "--app=alchemy.ar.ar_celery", "worker", "-Q", "ar_celery", "-c", "2", "--autoscale=100,2", "-l", "info", "--max-tasks-per-child", "1", "-n", "ar_celery"]
+    entrypoint: ["celery"]
+    command: [
+        "--app=alchemy.ar.ar_celery",
+        "worker",
+        "-Q", "ar_celery",
+        "-c", "2",
+        "--autoscale=10,2",
+        "-l", "info",
+        "--max-tasks-per-child", "1",
+        "-n", "ar_celery%I"
+    ]
     depends_on:
       - redis
       - db
@@ -67,7 +77,18 @@ services:
     env_file: .env
     image: *img
     volumes: *default-volumes
-    entrypoint: ["celery", "--app=alchemy.train.train_celery", "worker", "-Q", "train_celery", "-c", "2", "--autoscale=100,2", "-l", "info", "--max-tasks-per-child", "1", "-n", "train_celery"]
+    entrypoint: [ "celery" ]
+    command: [
+        "--app=alchemy.train.train_celery",
+        "worker",
+        "-Q", "train_celery",
+        "-c", "2",
+        "--autoscale=10,2",
+        "-l", "info",
+        "--max-tasks-per-child", "1",
+        "-n", "train_celery%I"
+    ]
+
     depends_on:
       - redis
       - db
@@ -77,7 +98,16 @@ services:
     env_file: .env
     image: *img
     volumes: *default-volumes
-    entrypoint: ["celery", "--app=alchemy.train.gcp_celery", "worker", "-Q", "gcp_celery", "-c", "5", "--autoscale=100,2", "-l", "info", "-n", "gcp_celery"]
+    entrypoint: [ "celery" ]
+    command: [
+        "--app=alchemy.train.gcp_celery",
+        "worker",
+        "-Q", "gcp_celery",
+        "-c", "5",
+        "--autoscale=10,2",
+        "-l", "info",
+        "-n", "gcp_celery%I"
+    ]
     depends_on:
       - redis
       - db


### PR DESCRIPTION
* Change upper limit of autoscale from 100 to 10, since 100 is too much for a single machine deployment
* Added restart policies for the web servers and Nginx